### PR TITLE
Make get_model_class return nil if class doesn't exist

### DIFF
--- a/lib/meta_magic/controller.rb
+++ b/lib/meta_magic/controller.rb
@@ -17,6 +17,10 @@ module MetaMagic
     end
 
     def get_model_class
+      controller_name.classify.safe_constantize
+    end
+
+    def get_model_class!
       controller_name.classify.constantize
     end
   end

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -10,7 +10,34 @@ describe MetaMagic::Controller do
   it { should respond_to(:get_model_instance_variable) }
   it { should respond_to(:set_model_instance_variable) }
 
-  it 'should return the correct model class' do
-    expect(subject.get_model_class).to eq(FakeThing)
+  describe '.get_model_class' do
+    context 'when the controller has an associated model' do
+      it 'should return the correct model class' do
+        expect(subject.get_model_class).to eq(FakeThing)
+      end
+    end
+
+    context 'when the associated class doesn\'t exist' do
+      let(:controller) { NoModelController.new }
+      it 'should return nil' do
+        expect(subject.get_model_class).to be_nil
+      end
+    end
+  end
+
+  describe '.get_model_class!' do
+    context 'when the controller has an associated model' do
+      it 'should return the correct model class' do
+        expect(subject.get_model_class!).to eq(FakeThing)
+      end
+    end
+
+    context 'when the associated class doesn\'t exist' do
+      let(:controller) { NoModelController.new }
+      it 'should throw an exception' do
+        expect { subject.get_model_class! }.to raise_error(NameError)
+      end
+    end
   end
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,3 +15,8 @@ end
 class FakeThingsController < ActionController::Base
   include MetaMagic::Controller
 end
+
+class NoModelController < ActionController::Base
+  include MetaMagic::Controller
+end
+


### PR DESCRIPTION
Also add a `get_model_class!` option that still returns a `NameError`
if an associated class doesn’t exist